### PR TITLE
Fix collateral selection

### DIFF
--- a/src/Contract/Config.purs
+++ b/src/Contract/Config.purs
@@ -140,7 +140,10 @@ defaultTimeParams =
 defaultSynchronizationParams :: ContractSynchronizationParams
 defaultSynchronizationParams =
   { syncBackendWithWallet:
-      { errorOnTimeout: false, beforeCip30Methods: true, beforeBalancing: true }
+      { errorOnTimeout: false
+      , beforeCip30Methods: false
+      , beforeBalancing: true
+      }
   , syncWalletWithTxInputs: { errorOnTimeout: false, beforeCip30Sign: true }
   , syncWalletWithTransaction:
       { errorOnTimeout: false, beforeTxConfirmed: true }

--- a/src/Internal/BalanceTx/Collateral.purs
+++ b/src/Internal/BalanceTx/Collateral.purs
@@ -60,24 +60,15 @@ addTxCollateralReturn
   -> Address
   -> BalanceTxM Transaction
 addTxCollateralReturn collateral transaction ownAddress =
-  let
-    collAdaValue :: BigInt
-    collAdaValue = foldl adaValue' zero collateral
-
-    collNonAdaAsset :: NonAdaAsset
-    collNonAdaAsset = foldMap nonAdaAsset collateral
-  in
-    case collAdaValue <= minRequiredCollateral && collNonAdaAsset == mempty of
-      true ->
-        pure transaction
-      false ->
-        setTxCollateralReturn collAdaValue collNonAdaAsset
+  case collAdaValue <= minRequiredCollateral && collNonAdaAsset == mempty of
+    true ->
+      pure transaction
+    false ->
+      setTxCollateralReturn
   where
   setTxCollateralReturn
-    :: BigInt
-    -> NonAdaAsset
-    -> BalanceTxM Transaction
-  setTxCollateralReturn collAdaValue collNonAdaAsset = do
+    :: BalanceTxM Transaction
+  setTxCollateralReturn = do
     let
       maxBigNumAdaValue :: Coin
       maxBigNumAdaValue = wrap (BigNum.toBigInt BigNum.maxValue)
@@ -122,6 +113,12 @@ addTxCollateralReturn collateral transaction ownAddress =
         false ->
           Left $ CollateralReturnError
             "Negative totalCollateral after covering min-utxo-ada requirement."
+
+  collAdaValue :: BigInt
+  collAdaValue = foldl adaValue' zero collateral
+
+  collNonAdaAsset :: NonAdaAsset
+  collNonAdaAsset = foldMap nonAdaAsset collateral
 
 --------------------------------------------------------------------------------
 -- Helpers

--- a/src/Internal/BalanceTx/Collateral/Select.purs
+++ b/src/Internal/BalanceTx/Collateral/Select.purs
@@ -36,7 +36,7 @@ import Data.Tuple.Nested (type (/\), (/\))
 import Effect (Effect)
 
 minRequiredCollateral :: BigInt
-minRequiredCollateral = BigInt.fromInt 5_000_000
+minRequiredCollateral = BigInt.fromInt 3_000_000
 
 -- | A constant that limits the number of candidate utxos for collateral
 -- | selection, thus maintaining acceptable time complexity.

--- a/src/Internal/Contract/Sign.purs
+++ b/src/Internal/Contract/Sign.purs
@@ -41,8 +41,7 @@ signTransaction tx = do
     Nami nami -> liftAff $ callCip30Wallet nami \nw -> flip nw.signTx tx
     Gero gero -> liftAff $ callCip30Wallet gero \nw -> flip nw.signTx tx
     Flint flint -> liftAff $ callCip30Wallet flint \nw -> flip nw.signTx tx
-    Eternl eternl -> do
-      liftAff $ callCip30Wallet eternl \nw -> flip nw.signTx tx
+    Eternl eternl -> liftAff $ callCip30Wallet eternl \nw -> flip nw.signTx tx
     Lode lode -> liftAff $ callCip30Wallet lode \nw -> flip nw.signTx tx
     NuFi nufi -> liftAff $ callCip30Wallet nufi \w -> flip w.signTx tx
     Lace nufi -> liftAff $ callCip30Wallet nufi \w -> flip w.signTx tx


### PR DESCRIPTION
This addresses some bug reports regarding collateral selection. The changes are as follows:
- try to account for minUTxO value during selection
- reduce minimum collateral to 3 ADA
- try to select collateral from all wallet UTxOs if initial selection fails
- change `beforeCip30Methods` to `false` in `defaultSynchronizationParams` to prevent chain query while signing (addresses `Could not get utxo` error)