### PR TITLE
Expose `startPlutipContractEnv` and `runCleanup`

### DIFF
--- a/src/Internal/Plutip/Server.purs
+++ b/src/Internal/Plutip/Server.purs
@@ -1,6 +1,9 @@
 module Ctl.Internal.Plutip.Server
   ( runPlutipContract
   , withPlutipContractEnv
+  , startPlutipContractEnv
+  , runCleanup
+  , whenError
   , startPlutipCluster
   , stopPlutipCluster
   , startPlutipServer


### PR DESCRIPTION
Used for parallel test
