### PR TITLE
Add `utxosWithAssetClass` and `utxosWithCurrencySymbol` to the `QueryHandle`

### DIFF
--- a/src/Contract/Utxos.purs
+++ b/src/Contract/Utxos.purs
@@ -89,6 +89,7 @@ utxosWithAssetClass symbol name = do
 utxosWithCurrencySymbol :: CurrencySymbol -> Contract UtxoMap
 utxosWithCurrencySymbol symbol = do
   queryHandle <- getQueryHandle
-  cardanoUtxoMap <- liftedE $ liftAff $ queryHandle.utxosWithCurrencySymbol symbol
+  cardanoUtxoMap <- liftedE $ liftAff $ queryHandle.utxosWithCurrencySymbol
+    symbol
   liftContractM "utxosAt: failed to convert utxos"
     $ toPlutusUtxoMap cardanoUtxoMap

--- a/src/Contract/Utxos.purs
+++ b/src/Contract/Utxos.purs
@@ -4,6 +4,7 @@
 module Contract.Utxos
   ( getUtxo
   , utxosAt
+  , utxosWithAssetClass
   , module X
   ) where
 
@@ -21,8 +22,10 @@ import Ctl.Internal.Plutus.Conversion
   , toPlutusUtxoMap
   )
 import Ctl.Internal.Plutus.Types.Address (class PlutusAddress, getAddress)
+import Ctl.Internal.Plutus.Types.CurrencySymbol (CurrencySymbol)
 import Ctl.Internal.Plutus.Types.Transaction (TransactionOutput, UtxoMap)
 import Ctl.Internal.Plutus.Types.Transaction (UtxoMap) as X
+import Ctl.Internal.Types.TokenName (TokenName)
 import Ctl.Internal.Types.Transaction (TransactionInput)
 import Data.Maybe (Maybe)
 import Data.Set (member) as Set
@@ -70,3 +73,14 @@ getUtxo oref = do
   cardanoTxOutput <- liftedE $ liftAff $ queryHandle.getUtxoByOref oref
   for cardanoTxOutput
     (liftContractM "getUtxo: failed to convert tx output" <<< toPlutusTxOutput)
+
+utxosWithAssetClass
+  :: CurrencySymbol
+  -> TokenName
+  -> Contract UtxoMap
+utxosWithAssetClass symbol name = do
+  queryHandle <- getQueryHandle
+  cardanoUtxoMap <- liftedE $ liftAff $ queryHandle.utxosWithAssetClass symbol
+    name
+  liftContractM "utxosAt: failed to convert utxos"
+    $ toPlutusUtxoMap cardanoUtxoMap

--- a/src/Contract/Utxos.purs
+++ b/src/Contract/Utxos.purs
@@ -5,6 +5,7 @@ module Contract.Utxos
   ( getUtxo
   , utxosAt
   , utxosWithAssetClass
+  , utxosWithCurrencySymbol
   , module X
   ) where
 
@@ -82,5 +83,12 @@ utxosWithAssetClass symbol name = do
   queryHandle <- getQueryHandle
   cardanoUtxoMap <- liftedE $ liftAff $ queryHandle.utxosWithAssetClass symbol
     name
+  liftContractM "utxosAt: failed to convert utxos"
+    $ toPlutusUtxoMap cardanoUtxoMap
+
+utxosWithCurrencySymbol :: CurrencySymbol -> Contract UtxoMap
+utxosWithCurrencySymbol symbol = do
+  queryHandle <- getQueryHandle
+  cardanoUtxoMap <- liftedE $ liftAff $ queryHandle.utxosWithCurrencySymbol symbol
   liftContractM "utxosAt: failed to convert utxos"
     $ toPlutusUtxoMap cardanoUtxoMap

--- a/src/Internal/Contract/Monad.purs
+++ b/src/Internal/Contract/Monad.purs
@@ -89,9 +89,9 @@ import Data.Set as Set
 import Data.Time.Duration (Milliseconds, Seconds)
 import Data.Traversable (for_, traverse, traverse_)
 import Effect (Effect)
+import Effect.AVar as AVar
 import Effect.Aff (Aff, ParAff, attempt, error, finally, supervise)
 import Effect.Aff.Class (liftAff)
-import Effect.AVar as AVar
 import Effect.Class (class MonadEffect, liftEffect)
 import Effect.Exception (Error, throw, try)
 import Effect.Ref (Ref)

--- a/src/Internal/Contract/QueryHandle.purs
+++ b/src/Internal/Contract/QueryHandle.purs
@@ -48,7 +48,6 @@ import Data.Newtype (unwrap, wrap)
 import Effect.Aff (Aff)
 import Effect.Class (liftEffect)
 import Effect.Exception (error)
-import Undefined (undefined)
 
 queryHandleForCtlBackend
   :: forall rest
@@ -129,8 +128,11 @@ queryHandleForBlockfrostBackend logParams backend =
         ( Blockfrost.getValidatorHashDelegationsAndRewards networkId
             stakeValidatorHash
         )
-  , utxosWithAssetClass: undefined
-  , utxosWithCurrencySymbol: undefined
+  , utxosWithAssetClass: \symbol name ->
+      runBlockfrostServiceM'
+        $ Blockfrost.utxosWithAssetClass symbol name
+  , utxosWithCurrencySymbol: runBlockfrostServiceM' <<<
+      Blockfrost.utxosWithCurrencySymbol
   }
   where
   runBlockfrostServiceM' :: forall (a :: Type). BlockfrostServiceM a -> Aff a

--- a/src/Internal/Contract/QueryHandle.purs
+++ b/src/Internal/Contract/QueryHandle.purs
@@ -25,6 +25,8 @@ import Ctl.Internal.QueryM.Kupo
   , getUtxoByOref
   , isTxConfirmed
   , utxosAt
+  , utxosWithAssetClass
+  , utxosWithCurrencySymbol
   ) as Kupo
 import Ctl.Internal.QueryM.Ogmios (SubmitTxR(SubmitFail, SubmitTxSuccess))
 import Ctl.Internal.QueryM.Pools
@@ -46,6 +48,7 @@ import Data.Newtype (unwrap, wrap)
 import Effect.Aff (Aff)
 import Effect.Class (liftEffect)
 import Effect.Exception (error)
+import Undefined (undefined)
 
 queryHandleForCtlBackend
   :: forall rest
@@ -84,6 +87,9 @@ queryHandleForCtlBackend runQueryM params backend =
   , getValidatorHashDelegationsAndRewards: \_ validatorHash ->
       Right <$> runQueryM'
         (QueryM.getValidatorHashDelegationsAndRewards validatorHash)
+  , utxosWithAssetClass: \symbol -> runQueryM' <<< Kupo.utxosWithAssetClass
+      symbol
+  , utxosWithCurrencySymbol: runQueryM' <<< Kupo.utxosWithCurrencySymbol
   }
 
   where
@@ -123,6 +129,8 @@ queryHandleForBlockfrostBackend logParams backend =
         ( Blockfrost.getValidatorHashDelegationsAndRewards networkId
             stakeValidatorHash
         )
+  , utxosWithAssetClass: undefined
+  , utxosWithCurrencySymbol: undefined
   }
   where
   runBlockfrostServiceM' :: forall (a :: Type). BlockfrostServiceM a -> Aff a

--- a/src/Internal/Contract/QueryHandle/Type.purs
+++ b/src/Internal/Contract/QueryHandle/Type.purs
@@ -11,6 +11,7 @@ import Ctl.Internal.Cardano.Types.Transaction
   , UtxoMap
   )
 import Ctl.Internal.Contract.QueryHandle.Error (GetTxMetadataError)
+import Ctl.Internal.Plutus.Types.CurrencySymbol (CurrencySymbol)
 import Ctl.Internal.QueryM.Ogmios
   ( AdditionalUtxoSet
   , CurrentEpoch
@@ -25,6 +26,7 @@ import Ctl.Internal.Types.Datum (DataHash, Datum)
 import Ctl.Internal.Types.EraSummaries (EraSummaries)
 import Ctl.Internal.Types.PubKeyHash (StakePubKeyHash)
 import Ctl.Internal.Types.Scripts (StakeValidatorHash)
+import Ctl.Internal.Types.TokenName (TokenName)
 import Ctl.Internal.Types.Transaction (TransactionHash, TransactionInput)
 import Ctl.Internal.Types.TransactionMetadata (GeneralTransactionMetadata)
 import Data.Either (Either)
@@ -54,4 +56,6 @@ type QueryHandle =
       NetworkId -> StakePubKeyHash -> AffE (Maybe DelegationsAndRewards)
   , getValidatorHashDelegationsAndRewards ::
       NetworkId -> StakeValidatorHash -> AffE (Maybe DelegationsAndRewards)
+  , utxosWithAssetClass :: CurrencySymbol -> TokenName -> AffE UtxoMap
+  , utxosWithCurrencySymbol :: CurrencySymbol -> AffE UtxoMap
   }

--- a/src/Internal/QueryM.purs
+++ b/src/Internal/QueryM.purs
@@ -49,7 +49,16 @@ module Ctl.Internal.QueryM
 
 import Prelude
 
-import Aeson (class DecodeAeson, Aeson, JsonDecodeError(TypeMismatch), decodeAeson, encodeAeson, getFieldOptional, parseJsonStringToAeson, stringifyAeson)
+import Aeson
+  ( class DecodeAeson
+  , Aeson
+  , JsonDecodeError(TypeMismatch)
+  , decodeAeson
+  , encodeAeson
+  , getFieldOptional
+  , parseJsonStringToAeson
+  , stringifyAeson
+  )
 import Affjax (Error, Response, defaultRequest, request) as Affjax
 import Affjax.RequestBody as Affjax.RequestBody
 import Affjax.RequestHeader as Affjax.RequestHeader
@@ -57,7 +66,12 @@ import Affjax.ResponseFormat as Affjax.ResponseFormat
 import Affjax.StatusCode as Affjax.StatusCode
 import Control.Alt (class Alt)
 import Control.Alternative (class Alternative)
-import Control.Monad.Error.Class (class MonadError, class MonadThrow, liftEither, throwError)
+import Control.Monad.Error.Class
+  ( class MonadError
+  , class MonadThrow
+  , liftEither
+  , throwError
+  )
 import Control.Monad.Logger.Class (class MonadLogger)
 import Control.Monad.Reader.Class (class MonadAsk, class MonadReader)
 import Control.Monad.Reader.Trans (ReaderT(ReaderT), asks)
@@ -66,17 +80,72 @@ import Control.Parallel (class Parallel, parallel, sequential)
 import Control.Plus (class Plus)
 import Ctl.Internal.Cardano.Types.Transaction (PoolPubKeyHash)
 import Ctl.Internal.Helpers (logWithLevel)
-import Ctl.Internal.JsWebSocket (JsWebSocket, Url, _mkWebSocket, _onWsConnect, _onWsError, _onWsMessage, _removeOnWsError, _wsClose, _wsFinalize, _wsSend)
+import Ctl.Internal.JsWebSocket
+  ( JsWebSocket
+  , Url
+  , _mkWebSocket
+  , _onWsConnect
+  , _onWsError
+  , _onWsMessage
+  , _removeOnWsError
+  , _wsClose
+  , _wsFinalize
+  , _wsSend
+  )
 import Ctl.Internal.Logging (Logger, mkLogger)
-import Ctl.Internal.QueryM.Dispatcher (DispatchError(JsError, JsonError, FaultError, ListenerCancelled), Dispatcher, GenericPendingRequests, PendingRequests, PendingSubmitTxRequests, RequestBody, WebsocketDispatch, dispatchErrorToError, mkWebsocketDispatch, newDispatcher, newPendingRequests) as ExportDispatcher
-import Ctl.Internal.QueryM.Dispatcher (DispatchError(JsonError, FaultError, ListenerCancelled), Dispatcher, GenericPendingRequests, PendingRequests, PendingSubmitTxRequests, RequestBody, WebsocketDispatch, dispatchErrorToError, mkWebsocketDispatch, newDispatcher, newPendingRequests)
+import Ctl.Internal.QueryM.Dispatcher
+  ( DispatchError(JsError, JsonError, FaultError, ListenerCancelled)
+  , Dispatcher
+  , GenericPendingRequests
+  , PendingRequests
+  , PendingSubmitTxRequests
+  , RequestBody
+  , WebsocketDispatch
+  , dispatchErrorToError
+  , mkWebsocketDispatch
+  , newDispatcher
+  , newPendingRequests
+  ) as ExportDispatcher
+import Ctl.Internal.QueryM.Dispatcher
+  ( DispatchError(JsonError, FaultError, ListenerCancelled)
+  , Dispatcher
+  , GenericPendingRequests
+  , PendingRequests
+  , PendingSubmitTxRequests
+  , RequestBody
+  , WebsocketDispatch
+  , dispatchErrorToError
+  , mkWebsocketDispatch
+  , newDispatcher
+  , newPendingRequests
+  )
 import Ctl.Internal.QueryM.JsonWsp as JsonWsp
-import Ctl.Internal.QueryM.Ogmios (AdditionalUtxoSet, DelegationsAndRewardsR, OgmiosProtocolParameters, PoolIdsR, PoolParametersR, TxEvaluationFailure(AdditionalUtxoOverlap), TxEvaluationR(TxEvaluationR), TxHash, aesonObject)
+import Ctl.Internal.QueryM.Ogmios
+  ( AdditionalUtxoSet
+  , DelegationsAndRewardsR
+  , OgmiosProtocolParameters
+  , PoolIdsR
+  , PoolParametersR
+  , TxEvaluationFailure(AdditionalUtxoOverlap)
+  , TxEvaluationR(TxEvaluationR)
+  , TxHash
+  , aesonObject
+  )
 import Ctl.Internal.QueryM.Ogmios as Ogmios
 import Ctl.Internal.QueryM.UniqueId (ListenerId)
-import Ctl.Internal.ServerConfig (Host, ServerConfig, defaultOgmiosWsConfig, mkHttpUrl, mkServerUrl, mkWsUrl) as ExportServerConfig
+import Ctl.Internal.ServerConfig
+  ( Host
+  , ServerConfig
+  , defaultOgmiosWsConfig
+  , mkHttpUrl
+  , mkServerUrl
+  , mkWsUrl
+  ) as ExportServerConfig
 import Ctl.Internal.ServerConfig (ServerConfig, mkWsUrl)
-import Ctl.Internal.Service.Error (ClientError(ClientHttpError, ClientHttpResponseError, ClientDecodeJsonError), ServiceError(ServiceOtherError))
+import Ctl.Internal.Service.Error
+  ( ClientError(ClientHttpError, ClientHttpResponseError, ClientDecodeJsonError)
+  , ServiceError(ServiceOtherError)
+  )
 import Ctl.Internal.Types.ByteArray (byteArrayToHex)
 import Ctl.Internal.Types.CborBytes (CborBytes)
 import Ctl.Internal.Types.Chain as Chain
@@ -98,7 +167,15 @@ import Data.Tuple (fst)
 import Data.Tuple.Nested (type (/\), (/\))
 import Effect (Effect)
 import Effect.AVar (AVar)
-import Effect.Aff (Aff, Canceler(Canceler), ParAff, delay, launchAff_, makeAff, runAff_)
+import Effect.Aff
+  ( Aff
+  , Canceler(Canceler)
+  , ParAff
+  , delay
+  , launchAff_
+  , makeAff
+  , runAff_
+  )
 import Effect.Aff.Class (class MonadAff, liftAff)
 import Effect.Class (class MonadEffect, liftEffect)
 import Effect.Exception (Error, error)

--- a/src/Internal/Serialization/Address.purs
+++ b/src/Internal/Serialization/Address.purs
@@ -207,6 +207,10 @@ instance FromData Address where
 instance ToData Address where
   toData addr = toData <<< unwrap <<< addressBytes $ addr
 
+instance DecodeAeson Address where
+  decodeAeson = decodeAeson >=>
+    note (TypeMismatch "Address") <<< addressFromBech32
+
 foreign import data BaseAddress :: Type
 
 instance Show BaseAddress where

--- a/src/Internal/Service/Blockfrost.purs
+++ b/src/Internal/Service/Blockfrost.purs
@@ -21,6 +21,9 @@ module Ctl.Internal.Service.Blockfrost
       , PoolIds
       , PoolParameters
       , DelegationsAndRewards
+      , AssetAddresses
+      , AssetsOfPolicy
+      , AssetUtxosAtAddress
       )
   , BlockfrostStakeCredential(BlockfrostStakeCredential)
   , BlockfrostEraSummaries(BlockfrostEraSummaries)
@@ -56,6 +59,8 @@ module Ctl.Internal.Service.Blockfrost
   , runBlockfrostServiceTestM
   , submitTx
   , utxosAt
+  , utxosWithAssetClass
+  , utxosWithCurrencySymbol
   ) where
 
 import Prelude
@@ -82,6 +87,7 @@ import Affjax.RequestBody (RequestBody, arrayView, string) as Affjax
 import Affjax.RequestHeader (RequestHeader(ContentType, RequestHeader)) as Affjax
 import Affjax.ResponseFormat (string) as Affjax.ResponseFormat
 import Affjax.StatusCode (StatusCode(StatusCode)) as Affjax
+import Contract.Prelude (mconcat)
 import Contract.RewardAddress
   ( rewardAddressToBech32
   , stakePubKeyHashRewardAddress
@@ -136,6 +142,11 @@ import Ctl.Internal.Deserialization.PlutusData (deserializeData)
 import Ctl.Internal.Deserialization.Transaction
   ( convertGeneralTransactionMetadata
   )
+import Ctl.Internal.Plutus.Types.CurrencySymbol
+  ( CurrencySymbol
+  , adaSymbol
+  , getCurrencySymbol
+  )
 import Ctl.Internal.QueryM.Ogmios (TxEvaluationR)
 import Ctl.Internal.QueryM.Pools (DelegationsAndRewards)
 import Ctl.Internal.Serialization as Serialization
@@ -165,6 +176,7 @@ import Ctl.Internal.Service.Helpers
   , aesonObject
   , aesonString
   , decodeAssetClass
+  , decodePlutusAssetClass
   )
 import Ctl.Internal.Types.Aliases (Bech32String)
 import Ctl.Internal.Types.BigNum (BigNum)
@@ -200,6 +212,7 @@ import Ctl.Internal.Types.Scripts
   , plutusV2Script
   )
 import Ctl.Internal.Types.SystemStart (SystemStart(SystemStart))
+import Ctl.Internal.Types.TokenName (TokenName, adaToken, getTokenName)
 import Ctl.Internal.Types.Transaction
   ( TransactionHash
   , TransactionInput(TransactionInput)
@@ -344,6 +357,12 @@ data BlockfrostEndpoint
   | PoolParameters PoolPubKeyHash
   -- /accounts/{stake_address}
   | DelegationsAndRewards BlockfrostStakeCredential
+  -- /assets/{asset}/addresses?page={page}&count={count}
+  | AssetAddresses CurrencySymbol TokenName Int Int
+  -- /assets/policy/{policy_id}?page={page}&count={count}
+  | AssetsOfPolicy CurrencySymbol Int Int
+  -- /addresses/{address}/utxos/{asset}?page={page}&count={count}
+  | AssetUtxosAtAddress Address CurrencySymbol TokenName Int Int
 
 derive instance Generic BlockfrostEndpoint _
 derive instance Eq BlockfrostEndpoint
@@ -392,6 +411,36 @@ realizeEndpoint endpoint =
       "/pool/" <> poolPubKeyHashToBech32 poolPubKeyHash
     DelegationsAndRewards credential ->
       "/accounts/" <> blockfrostStakeCredentialToBech32 credential
+    AssetAddresses symbol name page count ->
+      let
+        encodedCurrencySymbol = byteArrayToHex $ getCurrencySymbol symbol
+        encodedTokenName = byteArrayToHex $ getTokenName name
+      in
+        "/assets/" <> encodedCurrencySymbol <> encodedTokenName <> "/addresses"
+          <> "/utxos?page="
+          <> show page
+          <> ("&count=" <> show count)
+          <> "&order=asc"
+    AssetsOfPolicy symbol page count ->
+      let
+        encodedCurrencySymbol = byteArrayToHex $ getCurrencySymbol symbol
+      in
+        "/assets/policy/" <> encodedCurrencySymbol <> "?page" <> show page
+          <> "&count"
+          <> show count
+          <> "&order=asc"
+    AssetUtxosAtAddress address symbol name page count ->
+      let
+        encodedAddress = addressBech32 address
+        encodedCurrencySymbol = byteArrayToHex $ getCurrencySymbol symbol
+        encodedTokenName = byteArrayToHex $ getTokenName name
+      in
+        "/addresses/" <> encodedAddress <> "/utxos/" <> encodedCurrencySymbol
+          <> encodedTokenName
+          <> "?page="
+          <> show page
+          <> ("&count=" <> show count)
+          <> "&order=asc"
 
 blockfrostGetRequest
   :: BlockfrostEndpoint
@@ -566,6 +615,74 @@ getOutputAddressesByTxHash txHash = runExceptT do
     blockfrostGetRequest (UtxosOfTransaction txHash)
       <#> handle404AsMempty <<< handleBlockfrostResponse
   pure $ _.address <<< unwrap <<< snd <$> unwrap blockfrostUtxoMap
+
+--------------------------------------------------------------------------------
+-- Get utxos of a specific asset class
+--------------------------------------------------------------------------------
+
+utxosWithAssetClass
+  :: CurrencySymbol
+  -> TokenName
+  -> BlockfrostServiceM (Either ClientError UtxoMap)
+utxosWithAssetClass symbol name = runExceptT $ do
+  addresses :: BlockfrostAssetAddresses <- ExceptT
+    (entriesOnPage addressesOnPage 1)
+  utxosOfAssetClassAtAddresses :: Array BlockfrostUtxosAtAddress <-
+    traverse (ExceptT <<< utxosOfAssetClassAtAddress) $ unwrap addresses
+  ExceptT $ resolveBlockfrostUtxosAtAddress
+    (mconcat utxosOfAssetClassAtAddresses)
+  where
+  addressesOnPage :: Int -> Int -> BlockfrostEndpoint
+  addressesOnPage = AssetAddresses symbol name
+
+  assetUtxosAtAddressOnPage :: Address -> Int -> Int -> BlockfrostEndpoint
+  assetUtxosAtAddressOnPage address =
+    AssetUtxosAtAddress address symbol name
+
+  utxosOfAssetClassAtAddress
+    :: Address
+    -> BlockfrostServiceM (Either ClientError BlockfrostUtxosAtAddress)
+  utxosOfAssetClassAtAddress address = entriesOnPage
+    (assetUtxosAtAddressOnPage address)
+    1
+
+entriesOnPage
+  :: forall (result :: Type) (a :: Type)
+   . Monoid result
+  => DecodeAeson result
+  => Newtype result (Array a)
+  => (Int -> Int -> BlockfrostEndpoint)
+  -> Int
+  -> BlockfrostServiceM (Either ClientError result)
+entriesOnPage paginatedEndpoint page = runExceptT $ do
+  let
+    -- Maximum number of results per page supported by Blockfrost:
+    maxNumResultsOnPage :: Int
+    maxNumResultsOnPage = 100
+
+  utxos <- ExceptT $
+    blockfrostGetRequest (paginatedEndpoint page maxNumResultsOnPage)
+      <#> handle404AsMempty <<< handleBlockfrostResponse
+  if Array.length (unwrap utxos) /= maxNumResultsOnPage then pure utxos
+  else append utxos <$> ExceptT (entriesOnPage paginatedEndpoint $ page + 1)
+
+--------------------------------------------------------------------------------
+-- Get utxos of a specific currency symbol
+--------------------------------------------------------------------------------
+
+utxosWithCurrencySymbol
+  :: CurrencySymbol
+  -> BlockfrostServiceM (Either ClientError UtxoMap)
+utxosWithCurrencySymbol symbol = runExceptT $ do
+  assets :: BlockfrostAssetsWithCurrencySymbol <- ExceptT
+    (entriesOnPage assetsOnPage 1)
+  utxos <- traverse
+    (\(symbol /\ name) -> ExceptT $ utxosWithAssetClass symbol name)
+    (unwrap assets)
+  pure $ Map.unions utxos
+  where
+  assetsOnPage :: Int -> Int -> BlockfrostEndpoint
+  assetsOnPage = AssetsOfPolicy symbol
 
 --------------------------------------------------------------------------------
 -- Get datum by hash
@@ -954,6 +1071,56 @@ instance DecodeAeson BlockfrostUtxosOfTransaction where
     decodeTxOref txHash = aesonObject $
       flip getField "output_index" >>> map \index ->
         TransactionInput { transactionId: txHash, index }
+
+--------------------------------------------------------------------------------
+-- BlockfrostAssetAddresses
+--------------------------------------------------------------------------------
+
+newtype BlockfrostAssetAddresses = BlockfrostAssetAddresses (Array Address)
+
+derive instance Generic BlockfrostAssetAddresses _
+derive instance Newtype BlockfrostAssetAddresses _
+derive newtype instance Semigroup BlockfrostAssetAddresses
+derive newtype instance Monoid BlockfrostAssetAddresses
+
+instance Show BlockfrostAssetAddresses where
+  show = genericShow
+
+instance DecodeAeson BlockfrostAssetAddresses where
+  decodeAeson = aesonArray (map wrap <<< traverse decodeAddressEntry)
+    where
+    decodeAddressEntry :: Aeson -> Either JsonDecodeError Address
+    decodeAddressEntry = aesonObject $ \obj -> do
+      bech32Address <- getField obj "address"
+      note (TypeMismatch "Expected bech32 encoded address")
+        (addressFromBech32 bech32Address)
+
+--------------------------------------------------------------------------------
+-- BlockfrostAssetsWithCurrencySymbol
+--------------------------------------------------------------------------------
+
+newtype BlockfrostAssetsWithCurrencySymbol = BlockfrostAssetsWithCurrencySymbol
+  (Array (CurrencySymbol /\ TokenName))
+
+derive instance Generic BlockfrostAssetsWithCurrencySymbol _
+derive instance Newtype BlockfrostAssetsWithCurrencySymbol _
+derive newtype instance Semigroup BlockfrostAssetsWithCurrencySymbol
+derive newtype instance Monoid BlockfrostAssetsWithCurrencySymbol
+
+instance Show BlockfrostAssetsWithCurrencySymbol where
+  show = genericShow
+
+instance DecodeAeson BlockfrostAssetsWithCurrencySymbol where
+  decodeAeson = aesonArray (map wrap <<< traverse decodeAddressEntry)
+    where
+    decodeAddressEntry
+      :: Aeson -> Either JsonDecodeError (CurrencySymbol /\ TokenName)
+    decodeAddressEntry = aesonObject $ \obj -> do
+      getField obj "asset" >>= case _ of
+        "lovelace" -> pure $ adaSymbol /\ adaToken
+        assetString -> do
+          let { before: symbol, after: name } = String.splitAt 56 assetString
+          decodePlutusAssetClass assetString symbol name
 
 --------------------------------------------------------------------------------
 -- BlockfrostTransactionOutput

--- a/src/Internal/Service/Blockfrost.purs
+++ b/src/Internal/Service/Blockfrost.purs
@@ -243,7 +243,7 @@ import Data.Show.Generic (genericShow)
 import Data.String (splitAt) as String
 import Data.Time.Duration (Seconds(Seconds), convertDuration)
 import Data.Traversable (for, for_, traverse)
-import Data.Tuple (Tuple(Tuple), fst, snd)
+import Data.Tuple (Tuple(Tuple), fst, snd, uncurry)
 import Data.Tuple.Nested (type (/\), (/\))
 import Data.UInt (UInt)
 import Effect.Aff (Aff)
@@ -676,9 +676,10 @@ utxosWithCurrencySymbol
 utxosWithCurrencySymbol symbol = runExceptT $ do
   assets :: BlockfrostAssetsWithCurrencySymbol <- ExceptT
     (entriesOnPage assetsOnPage 1)
-  utxos <- traverse
-    (\(symbol /\ name) -> ExceptT $ utxosWithAssetClass symbol name)
-    (unwrap assets)
+  utxos <-
+    traverse
+      (ExceptT <<< uncurry utxosWithAssetClass)
+      $ unwrap assets
   pure $ Map.unions utxos
   where
   assetsOnPage :: Int -> Int -> BlockfrostEndpoint

--- a/src/Internal/Service/Helpers.purs
+++ b/src/Internal/Service/Helpers.purs
@@ -3,6 +3,7 @@ module Ctl.Internal.Service.Helpers
   , aesonString
   , aesonObject
   , decodeAssetClass
+  , decodePlutusAssetClass
   ) where
 
 import Prelude
@@ -16,6 +17,7 @@ import Aeson
   )
 import Control.Apply (lift2)
 import Ctl.Internal.Cardano.Types.Value (CurrencySymbol, mkCurrencySymbol)
+import Ctl.Internal.Plutus.Types.CurrencySymbol as Plutus
 import Ctl.Internal.Types.ByteArray (hexToByteArray)
 import Ctl.Internal.Types.TokenName (TokenName, mkTokenName)
 import Data.Either (Either(Left), note)
@@ -53,6 +55,26 @@ decodeAssetClass assetString csString tnString =
   lift2 Tuple
     ( note (assetStringTypeMismatch "CurrencySymbol" csString)
         (mkCurrencySymbol =<< hexToByteArray csString)
+    )
+    ( note (assetStringTypeMismatch "TokenName" tnString)
+        (mkTokenName =<< hexToByteArray tnString)
+    )
+  where
+  assetStringTypeMismatch :: String -> String -> JsonDecodeError
+  assetStringTypeMismatch t actual =
+    TypeMismatch $
+      ("In " <> assetString <> ": Expected hex-encoded " <> t)
+        <> (", got: " <> actual)
+
+decodePlutusAssetClass
+  :: String
+  -> String
+  -> String
+  -> Either JsonDecodeError (Plutus.CurrencySymbol /\ TokenName)
+decodePlutusAssetClass assetString csString tnString =
+  lift2 Tuple
+    ( note (assetStringTypeMismatch "Plutus.CurrencySymbol" csString)
+        (Plutus.mkCurrencySymbol =<< hexToByteArray csString)
     )
     ( note (assetStringTypeMismatch "TokenName" tnString)
         (mkTokenName =<< hexToByteArray tnString)


### PR DESCRIPTION
The definitions used in the `CtlBackendQueryHandle` were brought over from liqwid-ctl. The ones in the `BlockfrostQueryHandle` are an attempt to be fully compatible with the Kupo ones while being as economical as possible with Blockfrost's api usage. Unfortunately, since Blockfrost lacks an endpoint for utxos containing a certain asset, the new endpoints can result in an unbounded number of requests (the overall flow is: "Addresses with this asset" -> "Utxos with this asset at an address" for each address).