### PR TITLE
Gustavo/additional queries for agora offchain

### DIFF
--- a/src/Contract/Utxos.purs
+++ b/src/Contract/Utxos.purs
@@ -4,6 +4,7 @@
 module Contract.Utxos
   ( getUtxo
   , utxosAt
+  , utxosInTransaction
   , utxosWithAssetClass
   , utxosWithCurrencySymbol
   , module X
@@ -27,7 +28,7 @@ import Ctl.Internal.Plutus.Types.CurrencySymbol (CurrencySymbol)
 import Ctl.Internal.Plutus.Types.Transaction (TransactionOutput, UtxoMap)
 import Ctl.Internal.Plutus.Types.Transaction (UtxoMap) as X
 import Ctl.Internal.Types.TokenName (TokenName)
-import Ctl.Internal.Types.Transaction (TransactionInput)
+import Ctl.Internal.Types.Transaction (TransactionHash, TransactionInput)
 import Data.Maybe (Maybe)
 import Data.Set (member) as Set
 import Effect.Aff.Class (liftAff)
@@ -83,7 +84,7 @@ utxosWithAssetClass symbol name = do
   queryHandle <- getQueryHandle
   cardanoUtxoMap <- liftedE $ liftAff $ queryHandle.utxosWithAssetClass symbol
     name
-  liftContractM "utxosAt: failed to convert utxos"
+  liftContractM "utxosWithAssetClass: failed to convert utxos"
     $ toPlutusUtxoMap cardanoUtxoMap
 
 utxosWithCurrencySymbol :: CurrencySymbol -> Contract UtxoMap
@@ -91,5 +92,13 @@ utxosWithCurrencySymbol symbol = do
   queryHandle <- getQueryHandle
   cardanoUtxoMap <- liftedE $ liftAff $ queryHandle.utxosWithCurrencySymbol
     symbol
-  liftContractM "utxosAt: failed to convert utxos"
+  liftContractM "utxosWithCurrencySymbol: failed to convert utxos"
+    $ toPlutusUtxoMap cardanoUtxoMap
+
+utxosInTransaction :: TransactionHash -> Contract UtxoMap
+utxosInTransaction symbol = do
+  queryHandle <- getQueryHandle
+  cardanoUtxoMap <- liftedE $ liftAff $ queryHandle.utxosInTransaction
+    symbol
+  liftContractM "utxosInTransaction: failed to convert utxos"
     $ toPlutusUtxoMap cardanoUtxoMap

--- a/src/Contract/Utxos.purs
+++ b/src/Contract/Utxos.purs
@@ -8,6 +8,7 @@ module Contract.Utxos
   , utxosWithAssetClass
   , utxosWithCurrencySymbol
   , utxosWithCurrencySymbolInTransaction
+  , allOutputsWithCurrencySymbol
   , module X
   ) where
 
@@ -125,3 +126,12 @@ utxosWithCurrencySymbolInTransaction symbol txHash =
   hasCurrencySymbol =
     view $ _output <<< _amount <<< to symbols <<< to (Array.elem symbol)
 
+allOutputsWithCurrencySymbol
+  :: CurrencySymbol
+  -> Contract UtxoMap
+allOutputsWithCurrencySymbol symbol = do
+  queryHandle <- getQueryHandle
+  cardanoUtxoMap <- liftedE $ liftAff $ queryHandle.allOutputsWithCurrencySymbol
+    symbol
+  liftContractM "allOutputsWithCurrencySymbol: failed to convert utxos"
+    $ toPlutusUtxoMap cardanoUtxoMap

--- a/src/Internal/Contract/QueryHandle.purs
+++ b/src/Internal/Contract/QueryHandle.purs
@@ -28,6 +28,7 @@ import Ctl.Internal.QueryM.Kupo
   , utxosInTransaction
   , utxosWithAssetClass
   , utxosWithCurrencySymbol
+  , allOutputsWithCurrencySymbol
   ) as Kupo
 import Ctl.Internal.QueryM.Ogmios (SubmitTxR(SubmitFail, SubmitTxSuccess))
 import Ctl.Internal.QueryM.Pools
@@ -91,6 +92,7 @@ queryHandleForCtlBackend runQueryM params backend =
       symbol
   , utxosWithCurrencySymbol: runQueryM' <<< Kupo.utxosWithCurrencySymbol
   , utxosInTransaction: runQueryM' <<< Kupo.utxosInTransaction
+  , allOutputsWithCurrencySymbol: runQueryM' <<< Kupo.allOutputsWithCurrencySymbol
   }
 
   where
@@ -136,6 +138,8 @@ queryHandleForBlockfrostBackend logParams backend =
   , utxosWithCurrencySymbol: runBlockfrostServiceM' <<<
       Blockfrost.utxosWithCurrencySymbol
   , utxosInTransaction: runBlockfrostServiceM' <<< Blockfrost.utxosInTransaction
+  , allOutputsWithCurrencySymbol: runBlockfrostServiceM' <<<
+      Blockfrost.allOutputsWithCurrencySymbol
   }
   where
   runBlockfrostServiceM' :: forall (a :: Type). BlockfrostServiceM a -> Aff a

--- a/src/Internal/Contract/QueryHandle.purs
+++ b/src/Internal/Contract/QueryHandle.purs
@@ -25,6 +25,7 @@ import Ctl.Internal.QueryM.Kupo
   , getUtxoByOref
   , isTxConfirmed
   , utxosAt
+  , utxosInTransaction
   , utxosWithAssetClass
   , utxosWithCurrencySymbol
   ) as Kupo
@@ -89,6 +90,7 @@ queryHandleForCtlBackend runQueryM params backend =
   , utxosWithAssetClass: \symbol -> runQueryM' <<< Kupo.utxosWithAssetClass
       symbol
   , utxosWithCurrencySymbol: runQueryM' <<< Kupo.utxosWithCurrencySymbol
+  , utxosInTransaction: runQueryM' <<< Kupo.utxosInTransaction
   }
 
   where
@@ -133,6 +135,7 @@ queryHandleForBlockfrostBackend logParams backend =
         $ Blockfrost.utxosWithAssetClass symbol name
   , utxosWithCurrencySymbol: runBlockfrostServiceM' <<<
       Blockfrost.utxosWithCurrencySymbol
+  , utxosInTransaction: runBlockfrostServiceM' <<< Blockfrost.utxosInTransaction
   }
   where
   runBlockfrostServiceM' :: forall (a :: Type). BlockfrostServiceM a -> Aff a

--- a/src/Internal/Contract/QueryHandle.purs
+++ b/src/Internal/Contract/QueryHandle.purs
@@ -18,7 +18,8 @@ import Ctl.Internal.QueryM (evaluateTxOgmios, getChainTip, submitTxOgmios) as Qu
 import Ctl.Internal.QueryM.CurrentEpoch (getCurrentEpoch) as QueryM
 import Ctl.Internal.QueryM.EraSummaries (getEraSummaries) as QueryM
 import Ctl.Internal.QueryM.Kupo
-  ( getDatumByHash
+  ( allOutputsWithCurrencySymbol
+  , getDatumByHash
   , getOutputAddressesByTxHash
   , getScriptByHash
   , getTxMetadata
@@ -28,7 +29,6 @@ import Ctl.Internal.QueryM.Kupo
   , utxosInTransaction
   , utxosWithAssetClass
   , utxosWithCurrencySymbol
-  , allOutputsWithCurrencySymbol
   ) as Kupo
 import Ctl.Internal.QueryM.Ogmios (SubmitTxR(SubmitFail, SubmitTxSuccess))
 import Ctl.Internal.QueryM.Pools
@@ -92,7 +92,8 @@ queryHandleForCtlBackend runQueryM params backend =
       symbol
   , utxosWithCurrencySymbol: runQueryM' <<< Kupo.utxosWithCurrencySymbol
   , utxosInTransaction: runQueryM' <<< Kupo.utxosInTransaction
-  , allOutputsWithCurrencySymbol: runQueryM' <<< Kupo.allOutputsWithCurrencySymbol
+  , allOutputsWithCurrencySymbol: runQueryM' <<<
+      Kupo.allOutputsWithCurrencySymbol
   }
 
   where

--- a/src/Internal/Contract/QueryHandle/Type.purs
+++ b/src/Internal/Contract/QueryHandle/Type.purs
@@ -60,4 +60,5 @@ type QueryHandle =
   , utxosWithAssetClass :: CurrencySymbol -> TokenName -> AffE UtxoMap
   , utxosWithCurrencySymbol :: CurrencySymbol -> AffE UtxoMap
   , utxosInTransaction :: TransactionHash -> AffE UtxoMap
+  , allOutputsWithCurrencySymbol :: CurrencySymbol -> AffE UtxoMap
   }

--- a/src/Internal/Contract/QueryHandle/Type.purs
+++ b/src/Internal/Contract/QueryHandle/Type.purs
@@ -56,6 +56,8 @@ type QueryHandle =
       NetworkId -> StakePubKeyHash -> AffE (Maybe DelegationsAndRewards)
   , getValidatorHashDelegationsAndRewards ::
       NetworkId -> StakeValidatorHash -> AffE (Maybe DelegationsAndRewards)
+  -- endpoints from ctl-extra
   , utxosWithAssetClass :: CurrencySymbol -> TokenName -> AffE UtxoMap
   , utxosWithCurrencySymbol :: CurrencySymbol -> AffE UtxoMap
+  , utxosInTransaction :: TransactionHash -> AffE UtxoMap
   }

--- a/src/Internal/QueryM/Kupo.purs
+++ b/src/Internal/QueryM/Kupo.purs
@@ -9,6 +9,7 @@ module Ctl.Internal.QueryM.Kupo
   , utxosAt
   , utxosWithAssetClass
   , utxosWithCurrencySymbol
+  , utxosInTransaction
   ) where
 
 import Prelude
@@ -236,6 +237,15 @@ utxosWithCurrencySymbol symbol = runExceptT do
     parameters = [ "unspent" ]
     encodedCurrencySymbol = byteArrayToHex $ getCurrencySymbol symbol
     endpoint = "/matches/" <> pattern <> "?" <> mconcat parameters
+  kupoUtxoMap <- ExceptT $ handleAffjaxResponse <$> kupoGetRequest endpoint
+  ExceptT $ resolveKupoUtxoMap kupoUtxoMap
+
+utxosInTransaction :: TransactionHash -> QueryM (Either ClientError UtxoMap)
+utxosInTransaction txHash = runExceptT do
+  let
+    pattern = "*@" <> encodedTxHash
+    encodedTxHash = byteArrayToHex $ unwrap txHash
+    endpoint = "/matches/" <> pattern
   kupoUtxoMap <- ExceptT $ handleAffjaxResponse <$> kupoGetRequest endpoint
   ExceptT $ resolveKupoUtxoMap kupoUtxoMap
 

--- a/src/Internal/QueryM/Kupo.purs
+++ b/src/Internal/QueryM/Kupo.purs
@@ -10,6 +10,7 @@ module Ctl.Internal.QueryM.Kupo
   , utxosWithAssetClass
   , utxosWithCurrencySymbol
   , utxosInTransaction
+  , allOutputsWithCurrencySymbol
   ) where
 
 import Prelude
@@ -246,6 +247,17 @@ utxosInTransaction txHash = runExceptT do
     pattern = "*@" <> encodedTxHash
     encodedTxHash = byteArrayToHex $ unwrap txHash
     endpoint = "/matches/" <> pattern
+  kupoUtxoMap <- ExceptT $ handleAffjaxResponse <$> kupoGetRequest endpoint
+  ExceptT $ resolveKupoUtxoMap kupoUtxoMap
+
+allOutputsWithCurrencySymbol :: CurrencySymbol -> QueryM (Either ClientError UtxoMap)
+allOutputsWithCurrencySymbol symbol = runExceptT do
+  let
+    pattern = encodedCurrencySymbol <> ".*"
+    -- both spent and unspent outputs will be queried. Note that 
+    parameters = [ ]
+    encodedCurrencySymbol = byteArrayToHex $ getCurrencySymbol symbol
+    endpoint = "/matches/" <> pattern <> "?" <> mconcat parameters
   kupoUtxoMap <- ExceptT $ handleAffjaxResponse <$> kupoGetRequest endpoint
   ExceptT $ resolveKupoUtxoMap kupoUtxoMap
 

--- a/src/Internal/QueryM/Kupo.purs
+++ b/src/Internal/QueryM/Kupo.purs
@@ -250,12 +250,13 @@ utxosInTransaction txHash = runExceptT do
   kupoUtxoMap <- ExceptT $ handleAffjaxResponse <$> kupoGetRequest endpoint
   ExceptT $ resolveKupoUtxoMap kupoUtxoMap
 
-allOutputsWithCurrencySymbol :: CurrencySymbol -> QueryM (Either ClientError UtxoMap)
+allOutputsWithCurrencySymbol
+  :: CurrencySymbol -> QueryM (Either ClientError UtxoMap)
 allOutputsWithCurrencySymbol symbol = runExceptT do
   let
     pattern = encodedCurrencySymbol <> ".*"
-    -- both spent and unspent outputs will be queried. Note that 
-    parameters = [ ]
+    -- both spent and unspent outputs will be queried. Note that
+    parameters = []
     encodedCurrencySymbol = byteArrayToHex $ getCurrencySymbol symbol
     endpoint = "/matches/" <> pattern <> "?" <> mconcat parameters
   kupoUtxoMap <- ExceptT $ handleAffjaxResponse <$> kupoGetRequest endpoint

--- a/src/Internal/Service/Blockfrost.purs
+++ b/src/Internal/Service/Blockfrost.purs
@@ -452,7 +452,8 @@ realizeEndpoint endpoint =
         encodedCurrencySymbol = byteArrayToHex $ getCurrencySymbol symbol
         encodedTokenName = byteArrayToHex $ getTokenName name
       in
-        "/assets/" <> encodedCurrencySymbol <> encodedTokenName <> "/transactions"
+        "/assets/" <> encodedCurrencySymbol <> encodedTokenName
+          <> "/transactions"
           <> "?page="
           <> show page
           <> ("&count=" <> show count)
@@ -717,9 +718,9 @@ allOutputsWithCurrencySymbol symbol = runExceptT $ do
     (entriesOnPage assetsOnPage 1)
   transactions :: BlockfrostAssetTransactions <-
     mconcat
-    <$> traverse
-      (ExceptT <<< uncurry assetTransactions)
-      (unwrap assets)
+      <$> traverse
+        (ExceptT <<< uncurry assetTransactions)
+        (unwrap assets)
   utxos <-
     traverse
       (ExceptT <<< utxosInTransaction)
@@ -1153,7 +1154,8 @@ instance DecodeAeson BlockfrostAssetAddresses where
 -- BlockfrostAssetTransactions
 --------------------------------------------------------------------------------
 
-newtype BlockfrostAssetTransactions = BlockfrostAssetTransactions (Array TransactionHash)
+newtype BlockfrostAssetTransactions = BlockfrostAssetTransactions
+  (Array TransactionHash)
 
 derive instance Generic BlockfrostAssetTransactions _
 derive instance Newtype BlockfrostAssetTransactions _


### PR DESCRIPTION
Added `utxosInTransaction` and `allOutputsWithCurrencySymbol` (i.e. spent or unspent outputs containing a currency symbol) to the QueryHandle and both backends.